### PR TITLE
Allow XPath expression starting with function call or returning text nodes

### DIFF
--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -298,9 +298,9 @@ sub DESTROY {
 
 sub xpath {
     # xpath || css selector を xpath に変換する
-    # copy from Web::Scraper
+    # based on Web::Scraper
     my $exp = shift;
-    my $xpath = $exp =~ m!^(?:/|id\()! ? $exp : HTML::Selector::XPath::selector_to_xpath($exp);
+    my $xpath = $exp =~ m!^(?:/|[a-z][a-z-]*[a-z]\()! ? $exp : HTML::Selector::XPath::selector_to_xpath($exp);
     decode_utf8($xpath);
 }
 

--- a/t/XPathFeed.t
+++ b/t/XPathFeed.t
@@ -167,6 +167,17 @@ sub _scheme : Test(5) {
     $xpf->clean;
 }
 
+sub _xpath : Test(4) {
+    my $self = shift;
+
+    is XPathFeed::xpath('id("hoge")'), 'id("hoge")';
+    is XPathFeed::xpath('string-length("foo")'), 'string-length("foo")';
+    is XPathFeed::xpath('//p/a'), '//p/a';
+
+    is XPathFeed::xpath('ul#hoge > li.huga'),
+        q{//ul[@id='hoge']/li[contains(concat(' ', normalize-space(@class), ' '), ' huga ')]};
+}
+
 __PACKAGE__->runtests;
 
 1;


### PR DESCRIPTION
- `//a/text()`のようにtext nodeを取得するXPathを評価すると空文字列になる。
  - `XPathFeed::extract()`がtext nodeに対応していない。
- `substring-before(substring-after(//a/@style, "background-image: url("), ")")`のようなXPathを評価すると空文字列になる
  - `XPathFeed::extract()`がXML::XPathEngine::(Literal|Number|Boolean)に対応していない。
  - 評価する前にクエリをすべて`XPathFeed::xpath()`に通している。クエリがXPathっぽくなかったらCSS selectorと見なして`HTML::Selector::XPath::selector_to_xpath`でXPathに変換するという処理をしているが、チェックがきつすぎて一部のXPathまでCSS selectorと見なされて変換処理され、XPathが壊れる
  - XML::XPathEngine::(Literal|Number|Boolean)を返すべきXPathを、`find_nodes`を使ってリストコンテキストで評価すると、XML::XPathEngine::NodeSet(XML::XPathEngine::NodeSet(子要素なし))みたいな構造のオブジェクトが返される気がする。
    - NodeSetには文字列、数値、真偽値を入れられないみたいな制限があるのかもしれない。XML::XPathEngine::(Literal|Number|Boolean)を持ったリストみたいなものが返されてほしい。
    - スカラーコンテキストで評価するとXML::XPathEngine::(Literal|Number|Boolean)が返される。

---
- [x] XPathFeed::xpathのテスト書く
- [ ] find_nodesのリストコンテキストの件について調べる
- [ ] XPathかどうか判定する正規表現はあれでいいのか

---
- HTML::TreeBuilder::XPathのドキュメントでは`find`というメソッドが定義されていることになっているが、正しくは`find_xpath`では？
- `findnodes`と`find_xpath`は具体的に何が違うのか？
