### PR TITLE
Disallow: /frame

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -57,6 +57,7 @@ get '/frame' => sub {
         [
             'Content-Type'    => 'text/html',
             'X-Frame-Options' => 'SAMEORIGIN',
+            'X-Robots-Tag'    => 'none',
         ],
         [$xpf->frame_content],
     );

--- a/app.psgi
+++ b/app.psgi
@@ -78,7 +78,7 @@ get '/feed' => sub {
 
 builder {
     enable 'Plack::Middleware::Static',
-        path => qr{^/(?:images|css|js)/},
+        path => qr{^/(?:images|css|js)/|^/robots\.txt$},
         root => $root->subdir('static');
 
     enable 'Plack::Middleware::ReverseProxy';

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /frame


### PR DESCRIPTION
Work in progress
- Google
  - [Controlling Crawling and Indexing - Webmasters — Google Developers](https://developers.google.com/webmasters/control-crawl-index/)
  - [Control crawling and indexing from search engines — Web Fundamentals](https://developers.google.com/web/fundamentals/discovery-and-distribution/optimizations-for-crawlers/control-crawling-and-indexing?hl=en): <q>Many people confuses crawling and indexing. Prohibiting crawling doesn't mean the page won't show up in the search results. For example, when a third party website has a link to one of your webpages which is blocked from crawling, the page may still be listed in search results (In that case, the result won't have detailed description).</q>

["XPathFeed Disallow: /frame 入れたほうが良い気がする(紳士として)"](https://twitter.com/bulkneets/status/324429717170167808)
